### PR TITLE
--orphans command for finding lost files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A near drop-in replacement for `rm` that uses the
 Written in the [D programming language](https://dlang.org/)
 using only D's Phobos standard library.
 
-**ONLY LINUX AND BSD ARE SUPPORTED!**
+**ONLY LINUX AND BSD ARE CURRENTLY SUPPORTED!**
 
 Windows won't work at all, and MacOS probably won't either.
 Any POSIX and Freedesktop compliant system should work fine.
@@ -65,17 +65,18 @@ additional long options for the `trash-d` specific features.
 - `-i`, `--interactive` Ask before each deletion.
 - `-f`, `--force` Don't prompt and ignore errors.
 - `--version` Output the version and exit.
-- `--empty` Empty the trash bin.
-- `--delete FILE` Delete a file from the trash.
 - `--list` List out the files in the trash.
+- `--orphans` List orphaned files in the trash.
+- `--delete FILE` Delete a file from the trash.
 - `--restore FILE` Restore a file from the trash.
+- `--empty` Empty the trash bin.
 - `--rm` Escape hatch to permanently delete a file.
 - `-h`, `--help` This help information.
 
 
 #### Option Precedence
 
-The `--help`, `--version`, `--list`, `--restore`, `--delete`, and
+The `--help`, `--version`, `--list`, `--orphans`, `--restore`, `--delete`, and
 `--empty` flags all cause the program to short-circuit and perform only that
 operation and no others. Their precedence is in that order exactly, and is
 intended to cause the least destruction.

--- a/source/app.d
+++ b/source/app.d
@@ -4,8 +4,8 @@
   The two files are separated for testing purposes
 */
 
-import run : OPTS, runCommands;
-import cli : parseOpts;
+import run : runCommands;
+import cli : OPTS, parseOpts;
 import util : err;
 
 import core.memory;
@@ -27,8 +27,8 @@ int main(string[] args) {
     switch (res) {
         case 0:
             break;
-        // This is a special case where the options parsing wants to stop
-        // execution but there was no error
+            // This is a special case where the options parsing wants to stop
+            // execution but there was no error
         case -1:
             return 0;
         default:

--- a/source/cli.d
+++ b/source/cli.d
@@ -40,6 +40,8 @@ struct Opts {
     // ===== Custom Options ====
     /// List out the files in the trash bin
     bool list;
+    /// List out the orphaned files in the trash bin
+    bool orphans;
     /// Empty the trash bin
     bool empty;
     /// Actually delete instead of moving to trash
@@ -95,10 +97,11 @@ int parseOpts(ref string[] args) {
                 "force|f", "Don't prompt and ignore errors.", &OPTS.force,
                 "version", "Output the version and exit.", &OPTS.ver,
 
-                "empty", "Empty the trash bin.", &OPTS.empty,
-                "delete", "Delete a file from the trash.", &OPTS.del,
                 "list", "List out the files in the trash.", &OPTS.list,
+		"orphans", "List orphaned files in the trash.", &OPTS.orphans,
                 "restore", "Restore a file from the trash.", &OPTS.restore,
+                "delete", "Delete a file from the trash.", &OPTS.del,
+                "empty", "Empty the trash bin.", &OPTS.empty,
                 "rm", "Escape hatch to permanently delete a file.", &OPTS.rm,
         );
         // dfmt on

--- a/source/operations.d
+++ b/source/operations.d
@@ -11,7 +11,7 @@ import std.algorithm;
 import std.datetime.systime : Clock;
 import std.file;
 import std.format : format;
-import std.path : baseName, stripExtension;
+import std.path : baseName, buildNormalizedPath, stripExtension;
 import std.range : array;
 import std.stdio;
 import std.string;
@@ -128,6 +128,21 @@ void list() {
     writefln("%-*s\t%-*s\t%s", maxname, "Name", maxpath, "Path", "Del. Date");
     foreach (TrashFile t; tf) {
         writefln("%-*s\t%-*s\t%s", maxname, t.file_name, maxpath, t.orig_path, t.deletion_date);
+    }
+}
+
+/**
+  List out the files that are in the trash bin but do not have matching
+  .trashinfo files so would not show up in --list.
+  These can be secretly lurking files that are wasting space
+*/
+void orphans() {
+    auto files = OPTS.files_dir.dirEntries(SpanMode.shallow);
+    auto tf = files.map!(f => buildNormalizedPath(OPTS.info_dir, f) ~ ".trashinfo")
+                 .filter!(p => !p.exists()).array();
+
+    foreach (TrashFile file; tf) {
+        writefln("%s", file.file_name);
     }
 }
 

--- a/source/run.d
+++ b/source/run.d
@@ -33,6 +33,12 @@ int runCommands(string[] args) {
         return 0;
     }
 
+    // Handle listing out orphans
+    if (OPTS.orphans) {
+        orphans();
+	return 0;
+    }
+
     // Handle restoring trash files
     if (OPTS.restore)
         return restoreOrDel(OPTS.restore, false);

--- a/source/run.d
+++ b/source/run.d
@@ -9,14 +9,13 @@
   - https://specifications.freedesktop.org/trash-spec/trashspec-latest.html
 */
 
-import cli : Opts, parseOpts;
+import cli : OPTS, parseOpts;
 import operations;
 import util : createMissingFolders, err, log;
+import ver : COPY_TEXT, VER_TEXT;
 
+import std.stdio : writefln;
 import std.string : startsWith;
-
-/// The parsed CLI options are stored here on a global `Opts` struct
-static Opts OPTS;
 
 /**
    Given the remaining string arguments and the global `OPTS` struct, runs the
@@ -24,6 +23,12 @@ static Opts OPTS;
    operations and acts as a secondary entrypoint that `main()` can `try`.
 */
 int runCommands(string[] args) {
+    // Print the version number and return
+    if (OPTS.ver) {
+        writefln("\033[1m%s\033[0m\n\n%s", VER_TEXT, COPY_TEXT);
+        return -1;
+    }
+
     // Create missing folders if needed
     createMissingFolders();
 
@@ -36,7 +41,7 @@ int runCommands(string[] args) {
     // Handle listing out orphans
     if (OPTS.orphans) {
         orphans();
-	return 0;
+        return 0;
     }
 
     // Handle restoring trash files

--- a/source/tests.d
+++ b/source/tests.d
@@ -63,6 +63,10 @@ unittest {
     parseOpts(args);
     assert(OPTS.list);
 
+    args = t ~ ["--orphans"];
+    parseOpts(args);
+    assert(OPTS.orphans);
+
     args = t ~ ["-f", "--empty"];
     parseOpts(args);
     assert(OPTS.force);
@@ -332,6 +336,28 @@ unittest {
 }
 
 /**
+   Test the orpahans command which lists files without trashinfos
+*/
+unittest {
+    // Run a command so that the trash directory is created
+    assert(mini(["--list"]) == 0);
+
+    string testname = "test.file";
+    string testfile = OPTS.files_dir ~ "/" ~ testname;
+    testfile.write("hello");
+    scope (failure)
+        testfile.remove();
+    assert(testfile.exists());
+
+    assert(mini(["--orphans"]) == 0);
+    assert(testfile.exists());
+
+    // Cleanup
+    scope (success)
+        test_trash_dir.rmdirRecurse();
+}
+
+/**
    Intentionally failing cases to ensure that these are properly handled and for
    code coverage
 */
@@ -350,6 +376,7 @@ unittest {
     // Restoring a file that doesn't exist
     assert(mini(["--restore", ne]) == 1);
     // Deleting a file that doesn't exist
+    assert(mini(["--rm", ne]) == 1)
 
     // Unknown options should just be ignored
     assert(mini(["--unknown"]) == 0);

--- a/source/tests.d
+++ b/source/tests.d
@@ -2,8 +2,8 @@
   Integration tests for trash-d
 */
 
-import run : OPTS, runCommands;
-import cli : parseOpts;
+import run : runCommands;
+import cli : OPTS, parseOpts;
 import trashfile : TrashFile;
 
 import std.file;
@@ -26,6 +26,9 @@ int mini(string[] args) {
     const int res = parseOpts(args);
     if (res != 0)
         return res;
+
+    // Test for a nasty bug that came up
+    assert(!(OPTS.trash_dir is null));
 
     // Enable verbosity and change the trash directory for testing
     OPTS.verbose = true;
@@ -342,7 +345,7 @@ unittest {
     // Run a command so that the trash directory is created
     assert(mini(["--list"]) == 0);
 
-    string testname = "test.file";
+    const string testname = "test.file";
     string testfile = OPTS.files_dir ~ "/" ~ testname;
     testfile.write("hello");
     scope (failure)
@@ -376,7 +379,7 @@ unittest {
     // Restoring a file that doesn't exist
     assert(mini(["--restore", ne]) == 1);
     // Deleting a file that doesn't exist
-    assert(mini(["--rm", ne]) == 1)
+    assert(mini(["--rm", ne]) == 1);
 
     // Unknown options should just be ignored
     assert(mini(["--unknown"]) == 0);

--- a/source/trashfile.d
+++ b/source/trashfile.d
@@ -2,7 +2,7 @@
    TrashFile structure which handles information related to a file in the trash
 */
 
-import run : OPTS;
+import cli : OPTS;
 import util : log;
 
 import core.sys.posix.sys.stat : S_IWUSR;

--- a/source/util.d
+++ b/source/util.d
@@ -2,7 +2,7 @@
   Helper utility functions to perform various common operations
 */
 
-import run : OPTS;
+import cli : OPTS;
 
 import core.stdc.errno : EXDEV;
 import std.stdio : stderr, stdin, writef;

--- a/source/ver.d
+++ b/source/ver.d
@@ -5,7 +5,7 @@
 import std.format : format;
 
 /// trash-d is versioned sequentially starting at 1
-const int VER = 12;
+const int VER = 13;
 
 /// Ever major release is given a new name
 /// Names are based on video game bosses


### PR DESCRIPTION
Files in the trash that do not have a matching .trashinfo will not show up in --list. This is per-spec, and is roughly how other implementations work. But that means files can be lurking in the trash directory and taking up space.

The new --orphans flag displays these so that the user knows they are there and can deal with them.