### PR TITLE
Don't stop deleting on a failure

### DIFF
--- a/source/tests.d
+++ b/source/tests.d
@@ -115,6 +115,29 @@ unittest {
 }
 
 /**
+   Test that deletions continue after a failure
+*/
+unittest {
+    string testfile = "test.file";
+    testfile.write("hello");
+    assert(testfile.exists());
+    auto tinfo = TrashFile(testfile, Clock.currTime());
+    assert(tinfo.writeable);
+
+    // This should return non-zero,
+    // indicating that there was at least one error,
+    // but testfile should be trashed.
+    assert(mini(["does-not-exist", testfile]) != 0);
+    assert(!testfile.exists());
+    assert(tinfo.file_path.exists());
+    assert(tinfo.info_path.exists());
+
+    // Cleanup
+    scope (success)
+        test_trash_dir.rmdirRecurse();
+}
+
+/**
    Test the usecase of trashing an empty folder, including the failing case
    without the -d flag, and then permanently deleting the folder from the trash
 */

--- a/source/trash/run.d
+++ b/source/trash/run.d
@@ -77,6 +77,7 @@ int runCommands(string[] args) {
         }
     }
 
+    int ret = 0;
     // Loop through the args, trashing each of them in turn
     foreach (string path; args) {
         // Arguments that start with a dash were unknown args
@@ -88,12 +89,11 @@ int runCommands(string[] args) {
 
         // If the path exists, delete trash the file
         // Handle the force --rm flag
-        int res;
-        res = trashOrRm(path);
+        int res = trashOrRm(path);
         if (res > 0)
-            return res;
+            ret = 1;
     }
 
     // Hooray, we made it all the way to the end!
-    return 0;
+    return ret;
 }


### PR DESCRIPTION
If a file is missing, continue trying to delete others
but (eventually) exit with a failure status.

This commit improves compatibility with GNU rm.

closes #13