### PR TITLE
Exit with success when using -I

### DIFF
--- a/source/trash/run.d
+++ b/source/trash/run.d
@@ -73,7 +73,7 @@ int runCommands(string[] args) {
     // because it will prompt more often.
     if (OPTS.interact_once && (args.length > 3 || OPTS.recursive)) {
         if (!prompt("remove %d arguments?", args.length)) {
-            return -1;
+            return 0;
         }
     }
 


### PR DESCRIPTION
Passing -I (--interactive-once) prompts the user
if many files will be deleted.
If the user enters no, execution was still successful,
so exit with zero.

This commit improves compatibility with GNU rm.