### PR TITLE
Exit with success on --help or --version

### DIFF
--- a/source/tests.d
+++ b/source/tests.d
@@ -24,8 +24,12 @@ const test_trash_dir = "test-trash";
 int mini(string[] args) {
     args = ["trash"] ~ args;
     const int res = parseOpts(args);
-    if (res != 0)
+    if (res == -1) {
+        // special return value meaning no failures but exit now
+        return 0;
+    } else if (res != 0) {
         return res;
+    }
 
     // Test for a nasty bug that came up
     assert(!(OPTS.trash_dir is null));
@@ -75,8 +79,8 @@ unittest {
     assert(OPTS.force);
     assert(OPTS.empty);
 
-    assert(mini(["--version"]) == -1);
-    assert(mini(["--help"]) == -1);
+    assert(mini(["--version"]) == 0);
+    assert(mini(["--help"]) == 0);
 }
 
 /**

--- a/source/trash/run.d
+++ b/source/trash/run.d
@@ -28,7 +28,7 @@ int runCommands(string[] args) {
     // Print the version number and return
     if (OPTS.ver) {
         writefln("\033[1m%s\033[0m\n\n%s", VER_TEXT, COPY_TEXT);
-        return -1;
+        return 0;
     }
 
     // Create missing folders if needed


### PR DESCRIPTION
I have no strong feelings about how programs should exit
when asked for --version or --help, but
this improves compatibility with GNU rm.