### PR TITLE
Prepend program name to prompts, help text

### DIFF
--- a/source/trash/opts.d
+++ b/source/trash/opts.d
@@ -150,7 +150,9 @@ int parseOpts(ref string[] args) {
     // This includes when no arguments are given
     if (helpInfo.helpWanted || arglen < 2) {
         // trash-d changes the formatting of the help text to be much nicer
-        string text = "Usage: \033[1mtrash [OPTIONS...] [FILES...]\033[0m\n";
+        string text = "Usage: \033[1m"
+                    ~ OPTS.prog_name
+                    ~ " [OPTIONS...] [FILES...]\033[0m\n";
         OutBuffer buf = new OutBuffer();
         defaultGetoptFormatter(buf, text, helpInfo.options, "\t%*s  %*s\t%*s%s\x0a");
         writefln("%s\n\n%s\n%s", VER_TEXT, buf, COPY_TEXT);

--- a/source/trash/util.d
+++ b/source/trash/util.d
@@ -47,7 +47,7 @@ int ferr(Char, A...)(in Char[] fmt, A args) {
    Prompts the user for a yes or no input, defaulting to no.
 */
 bool prompt(Char, A...)(in Char[] fmt, A args) {
-    writef("Are you sure you want to %s? [y/N] ", format(fmt, args));
+    writef(OPTS.prog_name ~ " : Are you sure you want to %s? [y/N] ", format(fmt, args));
     string input = stdin.readln().strip().toLower();
     return input == "y" || input == "yes";
 }


### PR DESCRIPTION
Before asking the user anything,
remind them which program is asking.
This is most helpful in pipelines.

Also, the --help text now uses the actual program name
instead of always `trash`.

This mimics GNU rm -- including the space *before* the colon.