### PR TITLE
Create a basic Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1655624069,
+        "narHash": "sha256-7g1zwTdp35GMTERnSzZMWJ7PG3QdDE8VOX3WsnOkAtM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0d68d7c857fe301d49cdcd56130e0beea4ecd5aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,5 @@
 {
-    description = ''
-        A near drop-in replacement for rm that uses the FreeDesktop trash bin.
-        Written in the D programming language using only D's Phobos standard library, and can be compiled with any recent D compiler. This includes GCC, so `trash-d` should run on any *NIX platform that GCC supports.
-    '';
+    description = "A near drop-in replacement for rm that uses the FreeDesktop trash bin.";
 
     inputs = {
         nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
@@ -16,7 +13,7 @@
                 name = "trash-d";
                 src = self;
 
-                propagatedBuildInputs = with pkgs; [
+                buildInputs = with pkgs; [
                     (dmd.overrideAttrs (old : {
                         doCheck = false;
                     }))
@@ -26,11 +23,10 @@
                     ronn
                 ];
 
-                buildPhase = "rake";
+                buildPhase = "rake build:release";
 
                 installPhase = ''
-                    mkdir -p $out/bin
-                    install -t $out/bin build/trash
+                    install -D -t $out/bin build/trash
                     mkdir -p $out/man/man1
                     ronn --roff --pipe MANUAL.md > $out/man/man1/trash.1
                 '';

--- a/flake.nix
+++ b/flake.nix
@@ -16,13 +16,14 @@
                 name = "trash-d";
                 src = self;
 
-                buildInputs = with pkgs; [
+                propagatedBuildInputs = with pkgs; [
                     (dmd.overrideAttrs (old : {
                         doCheck = false;
                     }))
                     gcc
                     rake
                     dub
+                    ronn
                 ];
 
                 buildPhase = "rake";
@@ -30,6 +31,8 @@
                 installPhase = ''
                     mkdir -p $out/bin
                     install -t $out/bin build/trash
+                    mkdir -p $out/man/man1
+                    ronn --roff --pipe MANUAL.md > $out/man/man1/trash.1
                 '';
             };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+    description = ''
+        A near drop-in replacement for rm that uses the FreeDesktop trash bin.
+        Written in the D programming language using only D's Phobos standard library, and can be compiled with any recent D compiler. This includes GCC, so `trash-d` should run on any *NIX platform that GCC supports.
+    '';
+
+    inputs = {
+        nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+        flake-utils.url = "github:numtide/flake-utils";
+    };
+
+    outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem (system:
+        let pkgs = nixpkgs.legacyPackages.${system}; in
+        {
+            defaultPackage = pkgs.stdenv.mkDerivation {
+                name = "trash-d";
+                src = self;
+
+                buildInputs = with pkgs; [
+                    (dmd.overrideAttrs (old : {
+                        doCheck = false;
+                    }))
+                    gcc
+                    rake
+                    dub
+                ];
+
+                buildPhase = "rake";
+
+                installPhase = ''
+                    mkdir -p $out/bin
+                    install -t $out/bin build/trash
+                '';
+            };
+        }
+    );
+}


### PR DESCRIPTION
Hiyo, let me start things off by saying this is the first time I'm creating a pull request in an open source project, so any feedback is appreciated!

This pull-request provides a` flake.nix` and a `flake.lock` file. Together they make this repository into a nix flake which would allow Nix users to simply install trash-d from the url of this repository. 

A couple of things to note: 
- this flake does not install a manpage yet, I still have to figure out how to do this
- dmd failed during the check phase so I disabled it (the check phase)
- I _think_ that `flake-utils.lib.eachDefaultSystem` includes MacOS as well. Since trash-d shouldn't work on mac I will have to disable it

Let me know what you think of the format of the file and I will make any chances necessary :smile: 